### PR TITLE
Dotnet 8 Upgrade

### DIFF
--- a/AdGoBye.ExamplePlugin/AdGoBye.ExamplePlugin.csproj
+++ b/AdGoBye.ExamplePlugin/AdGoBye.ExamplePlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/AdGoBye.ExamplePlugin/AdGoBye.ExamplePlugin.csproj
+++ b/AdGoBye.ExamplePlugin/AdGoBye.ExamplePlugin.csproj
@@ -12,6 +12,6 @@
 
     <ItemGroup>
       <PackageReference Include="AssetsTools.NET" Version="3.0.0" />
-      <PackageReference Include="Serilog" Version="3.1.2-dev-02097" />
+      <PackageReference Include="Serilog" Version="3.1.1" />
     </ItemGroup>
 </Project>

--- a/AdGoBye.Plugins/AdGoBye.Plugins.csproj
+++ b/AdGoBye.Plugins/AdGoBye.Plugins.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/AdGoBye/AdGoBye.csproj
+++ b/AdGoBye/AdGoBye.csproj
@@ -17,14 +17,14 @@
     </PropertyGroup>
     
     <ItemGroup>
-      <PackageReference Include="AssetsTools.NET" Version="3.0.0-preview4" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0-rc.2.23479.6" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0-rc.2.23479.6" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0-rc.2.23479.6" />
-      <PackageReference Include="Serilog" Version="3.1.0-dev-02078" />
-      <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
-      <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0-dev-00923" />
-      <PackageReference Include="Tomlyn" Version="0.16.2" />
+      <PackageReference Include="AssetsTools.NET" Version="3.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+      <PackageReference Include="Serilog" Version="3.1.1" />
+      <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+      <PackageReference Include="Tomlyn" Version="0.17.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/AdGoBye/AdGoBye.csproj
+++ b/AdGoBye/AdGoBye.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Optimize>true</Optimize>


### PR DESCRIPTION
- Bumps all project SDKs from Dotnet 7 to Dotnet 8.
- Bumps Nuget packages to the latest stable available for Dotnet 8.