### PR TITLE
Fix current workaround for "Deadlock of Hell"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ $RECYCLE.BIN/
 .DS_Store
 
 _NCrunch*
+
+# Visual Studio Directory
+/.vs


### PR DESCRIPTION
- Pass ThreadLogger into `Indexer.ParseFile`
- Changed `List` to `ConcurrentBag` for thread safety when getting content in parallel.