### PR TITLE
feat: Improve Steam Appname detection with more methods

### DIFF
--- a/AdGoBye/Indexer.cs
+++ b/AdGoBye/Indexer.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using AdGoBye.Plugins;
 using AssetsTools.NET.Extra;
 using Microsoft.EntityFrameworkCore;
@@ -474,16 +475,25 @@ public class Indexer
     {
         if (!string.IsNullOrEmpty(Settings.Options.WorkingFolder)) return Settings.Options.WorkingFolder;
         var appName = SteamParser.GetApplicationName();
-        var pathToCache = "/" + appName + "/" + appName + "/";
+        var pathToWorkingDir = $"{appName}/{appName}/";
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            return
-                $"/home/{Environment.UserName}/.steam/steam/steamapps/compatdata/438100/pfx/drive_c/users/steamuser/AppData/LocalLow" +
-                pathToCache;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return ConstructLinuxWorkingPath();
 
         var appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
             .Replace("Roaming", "LocalLow");
-        return appDataFolder + pathToCache;
+        return $"{appDataFolder}/{pathToWorkingDir}";
+
+        [SupportedOSPlatform("linux")]
+        string ConstructLinuxWorkingPath()
+        {
+            var protonWorkingPath =
+                $"/steamapps/compatdata/{SteamParser.Appid}/pfx/drive_c/users/steamuser/AppData/LocalLow/{pathToWorkingDir}";
+
+            if (string.IsNullOrEmpty(SteamParser.AlternativeLibraryPath))
+                return SteamParser.GetPathToSteamRoot() + protonWorkingPath;
+
+            return SteamParser.AlternativeLibraryPath + protonWorkingPath;
+        }
     }
 
 

--- a/AdGoBye/SteamParser.cs
+++ b/AdGoBye/SteamParser.cs
@@ -131,10 +131,15 @@ public static class SteamParser
 
     public static string GetPathToSteamRoot()
     {
-        // TODO: Steam running within Flatpak is not guaranteed to have ~/.steam because it runs in an isolated context
         if (OperatingSystem.IsLinux())
         {
-            return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + "/.steam/steam/";
+            const string dotSteam = "/.steam/steam/";
+            var homeSteamPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + dotSteam;
+            var flatpakSteamPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) +
+                                   "/.var/app/com.valvesoftware.Steam" + dotSteam;
+
+            if (Directory.Exists(homeSteamPath)) return homeSteamPath;
+            if (Directory.Exists(flatpakSteamPath)) return flatpakSteamPath;
         }
 
         if (OperatingSystem.IsWindows())

--- a/AdGoBye/SteamParser.cs
+++ b/AdGoBye/SteamParser.cs
@@ -148,6 +148,6 @@ public static class SteamParser
             return registryKey!.ToString()!.Replace("steam.exe", "");
         }
 
-        throw new InvalidOperationException("couldn't determine pathToSteamApps");
+        throw new InvalidOperationException("couldn't determine path to Steam root directory");
     }
 }

--- a/AdGoBye/SteamParser.cs
+++ b/AdGoBye/SteamParser.cs
@@ -1,0 +1,139 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Win32;
+using Serilog;
+
+namespace AdGoBye;
+
+[SuppressMessage("ReSharper", "StringLiteralTypo")]
+public static class SteamParser
+{
+    private const string Appid = "438100";
+    private static readonly ILogger Logger = Log.ForContext(typeof(SteamParser));
+
+    public static string GetApplicationName()
+    {
+        try
+        {
+            return ExtractAppName();
+        }
+        catch (Exception e)
+        {
+            DieFatally(e);
+        }
+
+        throw new InvalidOperationException();
+
+        void DieFatally(Exception e)
+        {
+            Logger.Fatal("We're unable to find your game's working folder (the folder above the cache), " +
+                         "please provide it manually in appsettings.json as 'WorkingFolder'.");
+            throw e;
+        }
+    }
+
+    private static string ExtractAppName()
+    {
+        var steamRootPath = GetPathToSteamRoot();
+
+        var appName = GetAppNameFromAppmanifest(steamRootPath) ?? GetAppNameFromVrManifest();
+        if (appName is not null) return appName;
+
+        Logger.Debug("Auto detection failed to get app from default path and vrmanifest");
+        var libraryWithAppId = GetLibraryWithAppId(steamRootPath) ??
+                               throw new InvalidOperationException(
+                                   $"GetLibraryWithAppId failed to find the AppId {Appid} in libraryfolders.vdf");
+
+        appName = GetAppNameFromAppmanifest(libraryWithAppId) ??
+                  throw new InvalidOperationException(
+                      $"GetLibraryWithAppId believes {libraryWithAppId} contains app but appmanifest is missing");
+
+        return appName;
+
+        // ReSharper disable once IdentifierTypo
+        string? GetAppNameFromAppmanifest(string path)
+        {
+            string line;
+            try
+            {
+                line = File.ReadLines(path + "/steamapps/" + $"appmanifest_{Appid}.acf")
+                    .First(readLine => readLine.Contains("name"));
+            }
+            catch (FileNotFoundException)
+            {
+                return null;
+            }
+
+            var words = line.Split("\t");
+            return words[3].Replace("\"", "");
+        }
+
+        string? GetAppNameFromVrManifest()
+        {
+            var expectingAppName = false;
+            IEnumerable<string>? vrAppManifest;
+            try
+            {
+                vrAppManifest = File.ReadLines(Path.Combine(steamRootPath, "config/", "steamapps.vrmanifest"));
+            }
+            catch (FileNotFoundException)
+            {
+                return null;
+            }
+
+            foreach (var line in vrAppManifest)
+            {
+                switch (expectingAppName)
+                {
+                    case false when line.Contains($"\"steam.app.{Appid}\""):
+                        expectingAppName = true;
+                        break;
+                    case true when line.Contains("name"):
+                        return line.Split(":")[1].Replace("\"", "").Trim();
+                    case true when line.Contains("steam.app."):
+                        Logger.Warning("VRManifest parser expected app name but got another appkey?");
+                        expectingAppName = false;
+                        break;
+                }
+            }
+
+            return null;
+        }
+    }
+
+
+    private static string? GetLibraryWithAppId(string pathToSteamRoot)
+    {
+        string? libraryPath = null;
+        foreach (var line in File.ReadLines(Path.Combine(pathToSteamRoot, "config/", "libraryfolders.vdf")))
+        {
+            // Assumes line will be \t\t"path"\t\t"pathToLibrary"
+            if (line.Contains("\"path\"")) libraryPath = line.Split("\t")[4].Replace("\"", "");
+
+            if (line.Contains($"\"{Appid}\"")) return libraryPath;
+        }
+
+        return null;
+    }
+
+
+    private static string GetPathToSteamRoot()
+    {
+        if (OperatingSystem.IsLinux())
+        {
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) +
+                                "/.steam/steam/");
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            var registryKey = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Valve\Steam",
+                "InstallPath",
+                null);
+
+            // ReSharper disable once StringLiteralTypo
+            return registryKey!.ToString()!.Replace("steam.exe", "");
+        }
+
+        throw new InvalidOperationException("couldn't determine pathToSteamApps");
+    }
+}

--- a/AdGoBye/SteamParser.cs
+++ b/AdGoBye/SteamParser.cs
@@ -31,9 +31,8 @@ public static class SteamParser
 
         void DieFatally(Exception e)
         {
-            Logger.Fatal("We're unable to find your game's working folder (the folder above the cache), " +
-                         "please provide it manually in appsettings.json as 'WorkingFolder'.");
-            throw e;
+            Logger.Fatal(e, "We're unable to find your game's working folder (the folder above the cache), " +
+                            "please provide it manually in appsettings.json as 'WorkingFolder'.");
         }
     }
 


### PR DESCRIPTION
Our current detection is kind of dumb (well, this one is as well but it has more attempts) and presumes the game will be installed in Steam's root folder, which isn't always the case.

This implements the other two detection methods I've mentioned in #49.
We first attempt to read the appmanifest from $STEAMROOT/steamapps, if this fails, we attempt to parse it out of $STEAMROOT/config/steamapps.vrmanifest which might contain the name if the user runs PCVR, if that fails only then we iterate over the user's library to try to find where the game is installed and retry the appmanifest detection from there.

If all of that fails, either the user doesn't have the game in the first place or Steam is being incredibly weird with us.

Addresses #49