### PR TITLE
Blocklist Callback

### DIFF
--- a/AdGoBye/Indexer.cs
+++ b/AdGoBye/Indexer.cs
@@ -328,7 +328,9 @@ public class Indexer
         {
             try
             {
-                Blocklist.Patch(content.VersionMeta.Path + "/__data", block.Value.ToArray());
+                var unmatchedObjects = Blocklist.Patch(content.VersionMeta.Path + "/__data", block.Value.ToArray());
+                if (Settings.Options.SendUnmatchedObjectsToDevs && unmatchedObjects is not null)
+                    Blocklist.SendUnpatchedObjects(content.Id, unmatchedObjects);
                 if (!Settings.Options.DryRun) content.VersionMeta.PatchedBy.Add("Blocklist");
             }
             catch (Exception e)

--- a/AdGoBye/Indexer.cs
+++ b/AdGoBye/Indexer.cs
@@ -330,7 +330,7 @@ public class Indexer
             {
                 var unmatchedObjects = Blocklist.Patch(content.VersionMeta.Path + "/__data", block.Value.ToArray());
                 if (Settings.Options.SendUnmatchedObjectsToDevs && unmatchedObjects is not null)
-                    Blocklist.SendUnpatchedObjects(content.Id, unmatchedObjects);
+                    Blocklist.SendUnpatchedObjects(content, unmatchedObjects);
                 if (!Settings.Options.DryRun) content.VersionMeta.PatchedBy.Add("Blocklist");
             }
             catch (Exception e)

--- a/AdGoBye/Settings.cs
+++ b/AdGoBye/Settings.cs
@@ -4,22 +4,27 @@ namespace AdGoBye;
 
 public static class Settings
 {
-    public class SettingsOptions
-    {
-        public string[]? Allowlist { get; set; }
-        public string? WorkingFolder { get; set; }
-        public int LogLevel { get; set; }
-        public bool EnableLive { get; set; }
-        public bool DryRun { get; set; }
-        public string[] BlocklistUrLs { get; set; } = [];
-    }
-    public static SettingsOptions Options { get; set; }
-
     static Settings()
     {
         var config = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json")
             .Build();
         Options = config.GetRequiredSection("Settings").Get<SettingsOptions>() ?? new SettingsOptions();
+    }
+
+    public static SettingsOptions Options { get; set; }
+
+    public class SettingsOptions
+    {
+        public string[]? Allowlist { get; set; }
+
+        public bool SendUnmatchedObjectsToDevs { get; set; }
+
+        public string? BlocklistUnmatchedServer { get; set; }
+        public string? WorkingFolder { get; set; }
+        public int LogLevel { get; set; }
+        public bool EnableLive { get; set; }
+        public bool DryRun { get; set; }
+        public string[] BlocklistUrLs { get; set; } = [];
     }
 }

--- a/AdGoBye/appsettings.json
+++ b/AdGoBye/appsettings.json
@@ -1,7 +1,7 @@
 {
     "Settings": {
         "AllowList": [],
-        "SendUnmatchedObjectsToDevs": true,
+        "SendUnmatchedObjectsToDevs": false,
         "BlocklistUnmatchedServer": "",
         "WorkingFolder": null,
         "EnableLive": true,

--- a/AdGoBye/appsettings.json
+++ b/AdGoBye/appsettings.json
@@ -1,6 +1,8 @@
 {
     "Settings": {
         "AllowList": [],
+        "SendUnmatchedObjectsToDevs": true,
+        "BlocklistUnmatchedServer": "",
         "WorkingFolder": null,
         "EnableLive": true,
         "LogLevel": 0,


### PR DESCRIPTION
This implements #31, which implements a setting which I've called Blocklist Callback. It essentially sends hashes of unmatched Blocklist objects to a server in appsettings.json.

The changes in AGB are small, we reuse the infrastructure of Blocklist missed objects which already exists in code, serialize the misses to JSON, hash the JSON of the misses and the World ID, then pass all the hashes to `PostAsJsonAsync` which turns the byte arrays of the hashes into Base64.

Since hashes are one-way, hashes that the server can't reproduce are not usable, which allows us to filter away Blocklists we don't manage and doesn't require the user to trust us.
*If the hash matches*, we can associate it to a Blocklist item on the server side, allowing us to know what needs to be updated.

This is currently missing the server component which I'm still in the process of working on, I don't believe the AGB side should require many changes beyond this.

Once the server is complete, released and deployed, I'll swap out the default URL in Appsettings (without enabling this feature by default, as per #31!).