### PR TITLE
fix: Make DB save actions thread safe

### DIFF
--- a/AdGoBye/Blocklist.cs
+++ b/AdGoBye/Blocklist.cs
@@ -82,7 +82,7 @@ public static class Blocklist
             blocklistEntries.RemoveRange(danglingBlocklist);
         }
 
-        db.SaveChanges();
+        db.SaveChangesSafe();
 
         foreach (var optionsUrl in Settings.Options.BlocklistUrLs)
         {
@@ -112,7 +112,7 @@ public static class Blocklist
                 if (blocklistDownload.Value.ETag is not null) databaseQuery.ETag = blocklistDownload.Value.ETag;
             }
 
-            db.SaveChanges();
+            db.SaveChangesSafe();
         }
     }
 

--- a/AdGoBye/Indexer.cs
+++ b/AdGoBye/Indexer.cs
@@ -80,7 +80,7 @@ public class Indexer
             content.VersionMeta.PatchedBy = [];
         }
 
-        db.SaveChanges();
+        db.SaveChangesSafe();
     }
 
     public static void AddToIndex(string path)
@@ -142,7 +142,7 @@ public class Indexer
             content.VersionMeta.Path = directory.FullName;
             content.VersionMeta.PatchedBy = [];
 
-            db.SaveChanges();
+            db.SaveChangesSafe();
             return false;
         }
 
@@ -167,7 +167,7 @@ public class Indexer
 
             db.Content.Add(content);
             Logger.Information("Added {id} [{type}] to Index", content.Id, content.Type);
-            db.SaveChanges();
+            db.SaveChangesSafe();
             return;
         }
 
@@ -182,7 +182,7 @@ public class Indexer
                 indexCopy.VersionMeta.Version = content.VersionMeta.Version;
                 indexCopy.VersionMeta.Path = content.VersionMeta.Path;
                 indexCopy.VersionMeta.PatchedBy = [];
-                db.SaveChanges();
+                db.SaveChangesSafe();
                 return;
             // The second is an Imposter avatar, which we don't want to index.
             case ContentType.Avatar:
@@ -262,7 +262,7 @@ public class Indexer
 
 
         db.Content.Remove(indexMatch);
-        db.SaveChanges();
+        db.SaveChangesSafe();
         Logger.Information("Removed {id} from Index", indexMatch.Id);
     }
 

--- a/AdGoBye/Program.cs
+++ b/AdGoBye/Program.cs
@@ -52,7 +52,7 @@ Parallel.ForEach(db.Content.Include(content => content.VersionMeta), content =>
     Indexer.PatchContent(content);
 });
 
-db.SaveChanges();
+db.SaveChangesSafe();
 
 #pragma warning disable CS4014
 if (Settings.Options.EnableLive)

--- a/AdGoBye/State.cs
+++ b/AdGoBye/State.cs
@@ -6,9 +6,19 @@ public abstract class State
 {
     public sealed class IndexContext : DbContext
     {
+        private static readonly object SaveLock = new object();
+
         protected override void OnConfiguring(DbContextOptionsBuilder options)
         {
             options.UseSqlite("Data Source=database.db");
+        }
+
+        public void SaveChangesSafe()
+        {
+            lock (SaveLock)
+            {
+                SaveChanges();
+            }
         }
 
 #pragma warning disable CS8618 //


### PR DESCRIPTION
Use a lock to prevent exceptions from saving the DB on multiple threads.
Closes #62 