### PR TITLE
Bundle write process enhancements

### DIFF
--- a/AdGoBye/Indexer.cs
+++ b/AdGoBye/Indexer.cs
@@ -346,7 +346,7 @@ public class Indexer
 
         if (Settings.Options.EnableRecompression)
         {
-            if (estimatedUncompressedSize > (Settings.Options.RecompressionMemoryMaxMB * 1000L * 1000L) 
+            if (estimatedUncompressedSize > Settings.Options.RecompressionMemoryMaxMB * 1000L * 1000L
                 || estimatedUncompressedSize >= 1_900_000_000) // 1.9GB hard limit to leave a 100MB buffer just in case the estimation is off.
             {
                 var tempFileName = file + ".uncompressed";

--- a/AdGoBye/Settings.cs
+++ b/AdGoBye/Settings.cs
@@ -30,5 +30,7 @@ public static class Settings
         public bool DisablePluginInstallWarning { get; set; }
         public bool DisableBackupFile { get; set; }
         public bool EnableRecompression { get; set; }
+        public int RecompressionMemoryMaxMB { get; set; }
+        public int ZipBombSizeLimitMB { get; set; }
     }
 }

--- a/AdGoBye/appsettings.json
+++ b/AdGoBye/appsettings.json
@@ -11,7 +11,9 @@
         "DisableBackupFile": false,
         "BlocklistURLs": [],
         "DisablePluginInstallWarning": false,
-        "EnableRecompression":  false
+        "EnableRecompression": true,
+        "RecompressionMemoryMaxMB": 250,
+        "ZipBombSizeLimitMB": 8000
     },
     "Logging": {
         "LogLevel": {


### PR DESCRIPTION
- Attempt to detect ZIP bombs using directory infos from bundle.
- Fix exception for compression when uncompressed data is over 2GB by using a file instead of memory if the estimated size exceeds a user defined limit or a hard limit.
- Enable recompression by default.