### PR TITLE
fix: bundles modified by the blocklist don't save without plugins present

### DIFF
--- a/AdGoBye/Patcher.cs
+++ b/AdGoBye/Patcher.cs
@@ -74,10 +74,7 @@ namespace AdGoBye
                 {
                     try
                     {
-                        var unmatchedObjects = Blocklist.Patch(container, block.Value.ToArray());
-                        if (Settings.Options.SendUnmatchedObjectsToDevs && unmatchedObjects is not null)
-                            Blocklist.SendUnpatchedObjects(content, unmatchedObjects);
-                        if (unmatchedObjects is not null && unmatchedObjects.Count != block.Value.ToArray().Length)
+                        if (Blocklist.Patch(content, container, block.Value.ToArray()))
                             someoneModifiedBundle = true;
                     }
                     catch (Exception e)


### PR DESCRIPTION
Currently the bundles modified by the Blocklist will not be saved unless a plugin is present due to a faulty check for whether anything was modified.

I've simplified the logic by making Blocklist.Patch only responsible for informing the caller whether it modified the bundle or not and moved the SendUnpatchedObjects logic to within the Blocklist to better consolidate concerns.