### PR TITLE
Fix for rare case where version goes down

### DIFF
--- a/AdGoBye/Indexer.cs
+++ b/AdGoBye/Indexer.cs
@@ -104,7 +104,7 @@ public class Indexer
                 continue;
             }
 
-            if (highestVersion <= content.VersionMeta.Version) continue;
+            if (highestVersion <= content.VersionMeta.Version && Directory.Exists(content.VersionMeta.Path)) continue;
             content.VersionMeta.Version = highestVersion;
             content.VersionMeta.Path = highestVersionDir.FullName;
             content.VersionMeta.PatchedBy = [];


### PR DESCRIPTION
Fix for cases where the version of the file goes down and the higher version is deleted which results in a DirectoryNotFoundException.