### PR TITLE
[highprio] Fix Indexer logic

### DIFF
--- a/AdGoBye/Indexer.cs
+++ b/AdGoBye/Indexer.cs
@@ -55,8 +55,8 @@ public class Indexer
         var content = contentFolders
             .ExceptBy(db.Content.Select(content => content.StableContentName), info => info.Name)
             .Select(newContent => GetLatestFileVersion(newContent).HighestVersionDirectory)
-            .Where(directory => directory != null).ToList();
-        ;
+            // If we do a conditional check against null, the type checker thinks it's still null  
+            .OfType<DirectoryInfo>().ToList();
 
         if (content.Count != 0) AddToIndex(content);
 


### PR DESCRIPTION
This is a regression I've introduced in a3c774a7c9fb96c84d2d818e9b050bc9a8dc5f36.

`AddToIndexPart1` after my refactor added everything parasable into our add-to-database-bag, however the actual validation of what was should be added happens in `AddToIndexPart2`.

The logic to remove things entirely wasn't in `AddToIndexPart2`, but even assuming it was, we can't remove from `ConcurrentBag` (easily).

This means we try to add everything, including duplicates and imposters. This makes makes the indexing logic in v4 broken, which can work out fine but fails with imposter since Id is the identity key for Content.

This marries `AddToIndex1` and `AddToIndex2` back into one function, so that we can inherit the previous context and add to the database only when valid.