### PR TITLE
RFC: Generic Host, again

### DIFF
--- a/AdGoBye/AdGoBye.csproj
+++ b/AdGoBye/AdGoBye.csproj
@@ -32,9 +32,11 @@
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
         <PackageReference Include="Semver" Version="3.0.0-beta.1" />
         <PackageReference Include="Serilog" Version="4.0.0" />
         <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
+        <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0"/>
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="Tomlyn" Version="0.17.0" />
     </ItemGroup>

--- a/AdGoBye/AdGoBye.csproj
+++ b/AdGoBye/AdGoBye.csproj
@@ -37,6 +37,7 @@
         <PackageReference Include="Serilog" Version="4.0.0" />
         <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0"/>
+        <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2"/>
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="Tomlyn" Version="0.17.0" />
     </ItemGroup>

--- a/AdGoBye/Blocklist.cs
+++ b/AdGoBye/Blocklist.cs
@@ -22,7 +22,7 @@ public class Blocklist
 {
     private readonly ILogger<Blocklist> _logger;
     private readonly Settings.BlocklistOptions _options;
-    public Dictionary<string, HashSet<GameObjectInstance>>? Blocks;
+    public required Dictionary<string, HashSet<GameObjectInstance>> Blocks;
 
     public Blocklist(ILogger<Blocklist> logger, IOptions<Settings.BlocklistOptions> options)
     {
@@ -30,6 +30,8 @@ public class Blocklist
         _options = options.Value;
         UpdateNetworkBlocklists();
         Blocks = BlocklistsParser(GetBlocklists());
+        if (Blocks.Count == 0) logger.LogInformation("No blocklist has been loaded, is this intentional?");
+        ;
     }
 
 

--- a/AdGoBye/Blocklist.cs
+++ b/AdGoBye/Blocklist.cs
@@ -31,7 +31,6 @@ public class Blocklist
         UpdateNetworkBlocklists();
         Blocks = BlocklistsParser(GetBlocklists());
         if (Blocks.Count == 0) logger.LogInformation("No blocklist has been loaded, is this intentional?");
-        ;
     }
 
 

--- a/AdGoBye/Indexer.cs
+++ b/AdGoBye/Indexer.cs
@@ -16,9 +16,9 @@ namespace AdGoBye;
 public class Indexer
 {
     private readonly ILogger<Indexer> _logger;
-    public readonly string WorkingDirectory;
     private readonly Settings.IndexerOptions _options;
     private readonly Settings.SettingsOptionsV2 _optionsGlobal;
+    public readonly string WorkingDirectory;
 
     public Indexer(ILogger<Indexer> logger, IOptions<Settings.IndexerOptions> options, IOptions<Settings.SettingsOptionsV2> optionsGlobal)
     {
@@ -81,7 +81,7 @@ public class Indexer
 
         int SafeAllowlistCount()
         {
-            return _options.Allowlist is not null ? _options.Allowlist.Length : 0;
+            return _options.Allowlist?.Length ?? 0;
         }
     }
 

--- a/AdGoBye/Indexer.cs
+++ b/AdGoBye/Indexer.cs
@@ -17,15 +17,13 @@ public class Indexer
 {
     private readonly ILogger<Indexer> _logger;
     private readonly Settings.IndexerOptions _options;
-    private readonly Settings.SettingsOptionsV2 _optionsGlobal;
     public readonly string WorkingDirectory;
 
-    public Indexer(ILogger<Indexer> logger, IOptions<Settings.IndexerOptions> options, IOptions<Settings.SettingsOptionsV2> optionsGlobal)
+    public Indexer(ILogger<Indexer> logger, IOptions<Settings.IndexerOptions> options)
     {
         _logger = logger;
 
         _options = options.Value;
-        _optionsGlobal = optionsGlobal.Value;
         WorkingDirectory = GetWorkingDirectory();
         ManageIndex();
     }
@@ -138,7 +136,7 @@ public class Indexer
         var dbActionsContainer = new DatabaseOperationsContainer();
         Parallel.ForEach(paths, new ParallelOptions
             {
-                MaxDegreeOfParallelism = _optionsGlobal.MaxIndexerThreads
+                MaxDegreeOfParallelism = _options.MaxIndexerThreads
             },
             path => AddToIndex(path.FullName, ref dbActionsContainer));
         CommitToDatabase(dbActionsContainer);

--- a/AdGoBye/Indexer.cs
+++ b/AdGoBye/Indexer.cs
@@ -5,18 +5,26 @@ using System.Runtime.Versioning;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using AdGoBye.Database;
+using AssetsTools.NET;
 using AssetsTools.NET.Extra;
 using Microsoft.EntityFrameworkCore;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace AdGoBye;
 
 public class Indexer
 {
-    private static readonly ILogger Logger = Log.ForContext(typeof(Indexer));
-    public static readonly string WorkingDirectory = GetWorkingDirectory();
+    private readonly ILogger<Indexer> _logger;
+    public readonly string WorkingDirectory;
 
-    public static void ManageIndex()
+    public Indexer(ILogger<Indexer> logger)
+    {
+        _logger = logger;
+        WorkingDirectory = GetWorkingDirectory();
+        ManageIndex();
+    }
+
+    private void ManageIndex()
     {
         using var db = new AdGoByeContext();
         var container = new DatabaseOperationsContainer();
@@ -39,13 +47,13 @@ public class Indexer
                 // print exception with exception message if it's the last retry
                 if (retry == maxRetries - 1)
                 {
-                    Logger.Fatal(ex,
+                    _logger.LogCritical(ex,
                         "Max retries reached. Unable to find your game's Cache directory, please define the folder above manually in appsettings.json as 'WorkingFolder'.");
                     Environment.Exit(1);
                 }
                 else
                 {
-                    Logger.Error($"Directory not found attempting retry: {retry + 1} of {maxRetries}");
+                    _logger.LogCritical($"Directory not found attempting retry: {retry + 1} of {maxRetries}");
                 }
 
                 Thread.Sleep(delayMilliseconds);
@@ -62,7 +70,7 @@ public class Indexer
 
         if (content.Count != 0) AddToIndex(content);
 
-        Logger.Information("Finished Index processing");
+        _logger.LogInformation("Finished Index processing");
         return;
 
         static int SafeAllowlistCount()
@@ -71,7 +79,7 @@ public class Indexer
         }
     }
 
-    private static void VerifyDbTruth(ref DatabaseOperationsContainer container)
+    private void VerifyDbTruth(ref DatabaseOperationsContainer container)
     {
         using var db = new AdGoByeContext();
         foreach (var content in db.Content.Include(content => content.VersionMeta))
@@ -88,7 +96,7 @@ public class Indexer
             var (highestVersionDir, highestVersion) = GetLatestFileVersion(directoryMeta.Parent);
             if (highestVersionDir is null)
             {
-                Logger.Warning(
+                _logger.LogWarning(
                     "{parentDir} ({id}) is lingering with no content versions and should be deleted, Skipping for now",
                     directoryMeta.Parent, content.Id);
                 continue;
@@ -98,7 +106,7 @@ public class Indexer
             if (!File.Exists(highestVersionDir.FullName + "/__data"))
             {
                 container.RemoveContent.Add(content);
-                Logger.Warning(
+                _logger.LogWarning(
                     "{directory} is highest version but doesn't have __data, hell might have frozen over. Removed from Index",
                     highestVersionDir.FullName);
                 continue;
@@ -112,22 +120,25 @@ public class Indexer
         }
     }
 
-    public static void AddToIndex(string path)
+    public void AddToIndex(string path)
     {
         var container = new DatabaseOperationsContainer();
         AddToIndex(path, ref container);
         CommitToDatabase(container);
     }
 
-    public static void AddToIndex(IEnumerable<DirectoryInfo> paths)
+    public void AddToIndex(IEnumerable<DirectoryInfo> paths)
     {
         var dbActionsContainer = new DatabaseOperationsContainer();
-        Parallel.ForEach(paths, new ParallelOptions { MaxDegreeOfParallelism = Settings.Options.MaxIndexerThreads },
+        Parallel.ForEach(paths, new ParallelOptions
+            {
+                MaxDegreeOfParallelism = Settings.Options.MaxIndexerThreads
+            },
             path => AddToIndex(path.FullName, ref dbActionsContainer));
         CommitToDatabase(dbActionsContainer);
     }
 
-    private static void AddToIndex(string path, ref DatabaseOperationsContainer container)
+    private void AddToIndex(string path, ref DatabaseOperationsContainer container)
     {
         using var db = new AdGoByeContext();
         //   - Folder (StableContentName) [singleton, we want this]
@@ -146,7 +157,7 @@ public class Indexer
             var version = GetVersion(directory!.Name);
             if (version < content.VersionMeta.Version)
             {
-                Logger.Verbose(
+                _logger.LogTrace(
                     "Skipped Indexation of {directory} since it isn't an upgrade (Index: {greaterVersion}, Parsed: {lesserVersion})",
                     directory.FullName, content.VersionMeta.Version, version);
                 return;
@@ -170,12 +181,12 @@ public class Indexer
         {
             if (content.Type is ContentType.Avatar && IsAvatarImposter(content.VersionMeta.Path))
             {
-                Logger.Information("Skipping {path} because it's an Imposter avatar", content.VersionMeta.Path);
+                _logger.LogInformation("Skipping {path} because it's an Imposter avatar", content.VersionMeta.Path);
                 return;
             }
 
             container.AddContent.Add(content);
-            Logger.Information("Added {id} [{type}] to Index", content.Id, content.Type);
+            _logger.LogInformation("Added {id} [{type}] to Index", content.Id, content.Type);
             return;
         }
 
@@ -185,7 +196,7 @@ public class Indexer
             // The first is a world Unity version upgrade, in that case we simply use the newer version
             case ContentType.World:
                 if (!IsWorldHigherUnityVersion(indexCopy, content)) return;
-                Logger.Information("Upgrading {id} since it bumped Unity version ({directory})",
+                _logger.LogInformation("Upgrading {id} since it bumped Unity version ({directory})",
                     indexCopy.Id, content.VersionMeta.Path);
                 indexCopy.VersionMeta.Version = content.VersionMeta.Version;
                 indexCopy.VersionMeta.Path = content.VersionMeta.Path;
@@ -196,7 +207,7 @@ public class Indexer
             case ContentType.Avatar:
                 if (IsAvatarImposter(content.VersionMeta.Path))
                 {
-                    Logger.Information("Skipping {path} because it's an Imposter avatar", content.VersionMeta.Path);
+                    _logger.LogInformation("Skipping {path} because it's an Imposter avatar", content.VersionMeta.Path);
                     return;
                 }
 
@@ -207,10 +218,10 @@ public class Indexer
 
         return;
 
-        static bool IsAvatarImposter(string path)
+        bool IsAvatarImposter(string contentPath)
         {
             AssetsManager manager = new();
-            var bundleInstance = manager.LoadBundleFile(path + "/__data");
+            var bundleInstance = manager.LoadBundleFile(contentPath + "/__data");
             var assetInstance = manager.LoadAssetsFileFromBundle(bundleInstance, 0);
 
             foreach (var monoScript in assetInstance.file.GetAssetsOfType(AssetClassID.MonoScript))
@@ -224,7 +235,7 @@ public class Indexer
                 }
                 catch (Exception e)
                 {
-                    Logger.Warning(e, "AssetsTools likely failed to deserialize MonoBehaviour (PathId: {id}): ",
+                    _logger.LogWarning(e, "AssetsTools likely failed to deserialize MonoBehaviour (PathId: {id}): ",
                         monoScript.PathId);
                 }
             }
@@ -232,7 +243,7 @@ public class Indexer
             return false;
         }
 
-        static bool IsWorldHigherUnityVersion(Content indexedContent, Content newContent)
+        bool IsWorldHigherUnityVersion(Content indexedContent, Content newContent)
         {
             // Hack: [Regalia 2023-12-25T03:33:18Z] I'm not paid enough to parse Unity version strings reliably
             // This assumes the Unity versions always contains the major version at the start, is seperated by a dot and 
@@ -243,10 +254,10 @@ public class Indexer
             return int.Parse(newContentVersion) > int.Parse(indexedContentVersion);
         }
 
-        static string ResolveUnityVersion(string path)
+        string ResolveUnityVersion(string contentPath)
         {
             AssetsManager manager = new();
-            var bundleInstance = manager.LoadBundleFile(path + "/__data");
+            var bundleInstance = manager.LoadBundleFile(contentPath + "/__data");
             var assetInstance = manager.LoadAssetsFileFromBundle(bundleInstance, 1);
 
             foreach (var monoScript in assetInstance.file.GetAssetsOfType(AssetClassID.MonoBehaviour))
@@ -259,12 +270,12 @@ public class Indexer
                 }
                 catch (Exception e)
                 {
-                    Logger.Warning(e, "AssetsTools likely failed to deserialize MonoBehaviour (PathId: {id}): ",
+                    _logger.LogWarning(e, "AssetsTools likely failed to deserialize MonoBehaviour (PathId: {id}): ",
                         monoScript.PathId);
                 }
             }
 
-            Logger.Fatal("ResolveUnityVersion: Unable to parse unityVersion out for {path}", path);
+            _logger.LogCritical("ResolveUnityVersion: Unable to parse unityVersion out for {path}", contentPath);
             throw new InvalidOperationException();
         }
     }
@@ -287,7 +298,7 @@ public class Indexer
             .FirstOrDefault(content => content.StableContentName == directory.Parent!.Parent!.Name);
     }
 
-    public static void RemoveFromIndex(string path)
+    public void RemoveFromIndex(string path)
     {
         using var db = new AdGoByeContext();
         var indexMatch = GetFromIndex(path);
@@ -296,7 +307,7 @@ public class Indexer
 
         db.Content.Remove(indexMatch);
         db.SaveChanges();
-        Logger.Information("Removed {id} from Index", indexMatch.Id);
+        _logger.LogInformation("Removed {id} from Index", indexMatch.Id);
     }
 
     private static (DirectoryInfo? HighestVersionDirectory, int HighestVersion) GetLatestFileVersion(
@@ -315,7 +326,7 @@ public class Indexer
         return (highestVersionDir, highestVersion);
     }
 
-    private static Content? FileToContent(DirectoryInfo pathToFile)
+    private Content? FileToContent(DirectoryInfo pathToFile)
     {
         string id;
         int type;
@@ -342,7 +353,7 @@ public class Indexer
         };
     }
 
-    public static Tuple<string, int>? ParseFileMeta(string path)
+    public Tuple<string, int>? ParseFileMeta(string path)
     {
         AssetsManager manager = new();
         BundleFileInstance bundleInstance;
@@ -354,7 +365,7 @@ public class Indexer
         catch (NotImplementedException e)
         {
             if (e.Message != "Cannot handle bundles with multiple block sizes yet.") throw;
-            Logger.Warning(
+            _logger.LogWarning(
                 "{directory} has multiple block sizes, AssetsTools can't handle this yet. Skipping... ",
                 path);
             return null;
@@ -378,7 +389,7 @@ public class Indexer
 
         if (assetInstance is null)
         {
-            Logger.Warning(
+            _logger.LogWarning(
                 "Indexing {directory} caused no loadable bundle directory to exist, is this bundle valid?",
                 path);
             return null;
@@ -386,7 +397,7 @@ public class Indexer
 
         foreach (var monoScript in assetInstance.file.GetAssetsOfType(AssetClassID.MonoBehaviour))
         {
-            AssetsTools.NET.AssetTypeValueField gameObjectBase;
+            AssetTypeValueField gameObjectBase;
 
             try
             {
@@ -395,20 +406,20 @@ public class Indexer
             }
             catch (Exception e)
             {
-                Logger.Warning(e, "AssetsTools likely failed to deserialize MonoBehaviour (PathId: {id}): ",
+                _logger.LogWarning(e, "AssetsTools likely failed to deserialize MonoBehaviour (PathId: {id}): ",
                     monoScript.PathId);
                 continue;
             }
 
             if (gameObjectBase["blueprintId"].AsString == "")
             {
-                Logger.Warning("{directory} has no embedded ID for some reason, skipping this…", path);
+                _logger.LogWarning("{directory} has no embedded ID for some reason, skipping this…", path);
                 return null;
             }
 
             if (gameObjectBase["contentType"].AsInt >= 3)
             {
-                Logger.Warning(
+                _logger.LogWarning(
                     "{directory} is neither Avatar nor World but another secret other thing ({type}), skipping this...",
                     path, gameObjectBase["contentType"].AsInt);
                 return null;
@@ -439,7 +450,7 @@ public class Indexer
 
 
     [SuppressMessage("ReSharper", "StringLiteralTypo")]
-    private static string GetWorkingDirectory()
+    private string GetWorkingDirectory()
     {
         if (!string.IsNullOrEmpty(Settings.Options.Indexer.WorkingFolder))
             return Settings.Options.Indexer.WorkingFolder;
@@ -451,7 +462,7 @@ public class Indexer
         var customWorkingDir = ReadConfigFile(defaultWorkingDir);
         if (!string.IsNullOrEmpty(customWorkingDir))
             return customWorkingDir;
-        
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             return ConstructLinuxWorkingPath();
 
@@ -470,7 +481,7 @@ public class Indexer
         }
     }
 
-    private static string? ReadConfigFile(string path)
+    private string? ReadConfigFile(string path)
     {
         var configFile = Path.Combine(path, "config.json");
         if (!File.Exists(configFile))
@@ -487,12 +498,12 @@ public class Indexer
         }
         catch (JsonException e)
         {
-            Logger.Error(e, "Failed to parse config.json");
+            _logger.LogError(e, "Failed to parse config.json");
             return null;
         }
     }
 
-    private static string GetCacheDir()
+    private string GetCacheDir()
     {
         return Path.Combine(WorkingDirectory, "Cache-WindowsPlayer");
     }

--- a/AdGoBye/Live.cs
+++ b/AdGoBye/Live.cs
@@ -72,7 +72,7 @@ public static class Live
                 watcher.EnableRaisingEvents = true;
                 while (!stoppingToken.IsCancellationRequested)
                 {
-                    watcher.WaitForChanged(WatcherChangeTypes.Created, Timeout.Infinite);
+                    watcher.WaitForChanged(WatcherChangeTypes.Created, 500);
                 }
             });
         }
@@ -121,9 +121,9 @@ public static class Live
                 };
                 watcher.EnableRaisingEvents = true;
 
-                while (true)
+                while (!stoppingToken.IsCancellationRequested)
                 {
-                    watcher.WaitForChanged(WatcherChangeTypes.Created, Timeout.Infinite);
+                    watcher.WaitForChanged(WatcherChangeTypes.Created, 500);
                 }
             });
         }

--- a/AdGoBye/Live.cs
+++ b/AdGoBye/Live.cs
@@ -1,5 +1,6 @@
-using System.Diagnostics.CodeAnalysis;
-using Serilog;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 // ReSharper disable FunctionNeverReturns
 
@@ -9,149 +10,168 @@ public static class Live
 {
     private const string LoadStartIndicator = "[Behaviour] Preparing assets...";
     private const string LoadStopIndicator = "Entering world";
-    private static readonly ILogger Logger = Log.ForContext(typeof(Live));
     private static readonly EventWaitHandle Ewh = new(true, EventResetMode.ManualReset);
+    private static CancellationTokenSource _logwatcherStoppingToken = new();
 
-    public static void WatchNewContent(string path)
+    public static void RegisterLiveServices(this IServiceCollection services)
     {
-        using var watcher = new FileSystemWatcher(path);
-
-        watcher.NotifyFilter = NotifyFilters.Attributes
-                               | NotifyFilters.CreationTime
-                               | NotifyFilters.DirectoryName
-                               | NotifyFilters.FileName
-                               | NotifyFilters.LastAccess
-                               | NotifyFilters.LastWrite
-                               | NotifyFilters.Security
-                               | NotifyFilters.Size;
-
-        /* HACK: [Regalia 2023-11-18T19:43:50Z] FileSystemWatcher doesn't detect __data on Windows only
-          Instead, we track for __info and replace it with __data.
-          This has the implication that info is always created alongside data.
-          This might also break if the detection failure is caused intentionally by adversarial motive.
-        */
-        watcher.Created += (_, e) => Task.Run(() => ParseFile(e.FullPath.Replace("__info", "__data")));
-        watcher.Deleted += (_, e) => Task.Run(
-            () =>
-            {
-                Logger.Verbose("File removal: {directory}", e.FullPath);
-                Indexer.RemoveFromIndex(e.FullPath.Replace("__info", "__data"));
-            });
-
-        watcher.Error += (_, e) =>
-        {
-            switch (e.GetException())
-            {
-                case InternalBufferOverflowException:
-                    Logger.Error(
-                        "FileSystemWatcher's internal buffer experienced an overflow, we may have missed some file events!\n" +
-                        "Your Indexer state may not correct anymore, restart if something doesn't work.\n" +
-                        "If you experience this often, please tell us at https://github.com/AdGoBye/AdGoBye/issues.");
-                    break;
-                default:
-                    Logger.Error("FileSystemWatcher threw an exception: {exception}", e);
-                    break;
-            }
-        };
-
-        watcher.Filter = "__info";
-        watcher.IncludeSubdirectories = true;
-        watcher.EnableRaisingEvents = true;
-        while (true)
-        {
-            watcher.WaitForChanged(WatcherChangeTypes.Created, Timeout.Infinite);
-        }
+        services.AddHostedService<LogFileWatcher>();
+        services.AddHostedService<Logwatcher>();
+        services.AddHostedService<ContentWatcher>();
     }
 
-    private static async void ParseFile(string path)
+    internal class ContentWatcher(ILogger<ContentWatcher> logger) : BackgroundService
     {
-        var done = false;
-        while (!done)
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            try
+            await Task.Run(() =>
             {
-                Indexer.AddToIndex(path);
-                Ewh.WaitOne();
-                var newContent = Indexer.GetFromIndex(path);
-                if (newContent is not null) Patcher.PatchContent(newContent);
-                done = true;
-            }
-            catch (EndOfStreamException)
-            {
-                await Task.Delay(500);
-            }
-        }
-    }
+                using var watcher = new FileSystemWatcher(Indexer.WorkingDirectory);
 
+                watcher.NotifyFilter = NotifyFilters.Attributes
+                                       | NotifyFilters.CreationTime
+                                       | NotifyFilters.DirectoryName
+                                       | NotifyFilters.FileName
+                                       | NotifyFilters.LastAccess
+                                       | NotifyFilters.LastWrite
+                                       | NotifyFilters.Security
+                                       | NotifyFilters.Size;
 
-    [SuppressMessage("ReSharper", "MethodSupportsCancellation")]
-    public static void WatchLogFile(string path)
-    {
-        CancellationTokenSource ct = new();
-        var currentTask = Task.Run(() => HandleFileLock(GetNewestLog(), ct.Token));
+                // "Cancellation is cooperative and is not forced on the listener.
+                // The listener determines how to gracefully terminate in response to a cancellation request."
+                //
+                // Nothing consumes this token, this suggestion is not useful.
+                // ReSharper disable MethodSupportsCancellation
+                watcher.Created += (_, e) => Task.Run(() => ParseFile(e.FullPath.Replace("__info", "__data")));
+                watcher.Deleted += (_, e) => Task.Run(
+                    () =>
+                    {
+                        logger.LogTrace("File removal: {directory}", e.FullPath);
+                        Indexer.RemoveFromIndex(e.FullPath.Replace("__info", "__data"));
+                    });
+                // ReSharper restore MethodSupportsCancellation
 
-        using var watcher = new FileSystemWatcher(path);
-        watcher.NotifyFilter = NotifyFilters.FileName;
-        watcher.Created += (_, e) =>
-        {
-            ct.Cancel();
-            currentTask.Wait();
-            ct = new CancellationTokenSource();
-
-            // Assuming a new log file means a client restart, it's likely not loading any file.
-            // Let's take initiative and free any tasks.
-            Ewh.Set();
-
-            currentTask = Task.Run(() => HandleFileLock(e.FullPath, ct.Token));
-            Logger.Verbose("Rotated log parsing to {file}", e.Name);
-        };
-
-        watcher.Filter = "*.txt";
-        watcher.IncludeSubdirectories = false;
-        watcher.EnableRaisingEvents = true;
-        while (true)
-        {
-            watcher.WaitForChanged(WatcherChangeTypes.Created, Timeout.Infinite);
-        }
-    }
-
-    private static void HandleFileLock(string logFile, CancellationToken cancellationToken)
-    {
-        var sr = GetLogStream(logFile);
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            var output = sr.ReadToEnd();
-            var lines = output.Split(Environment.NewLine);
-            foreach (var line in lines)
-            {
-                switch (line)
+                watcher.Error += (_, e) =>
                 {
-                    case not null when line.Contains(LoadStartIndicator):
-                        Logger.Verbose("Expecting world load: {msg}", line);
-                        Ewh.Reset();
-                        break;
-                    case not null when line.Contains(LoadStopIndicator):
-                        Logger.Verbose("Expecting world load finish: {msg}", line);
-                        Ewh.Set();
-                        break;
+                    switch (e.GetException())
+                    {
+                        case InternalBufferOverflowException:
+                            logger.LogError(
+                                "FileSystemWatcher's internal buffer experienced an overflow, we may have missed some file events!\n" +
+                                "Your Indexer state may not correct anymore, restart if something doesn't work.\n" +
+                                "If you experience this often, please tell us at https://github.com/AdGoBye/AdGoBye/issues.");
+                            break;
+                        default:
+                            logger.LogError("FileSystemWatcher threw an exception: {exception}", e);
+                            break;
+                    }
+                };
+
+                watcher.Filter = "__info";
+                watcher.IncludeSubdirectories = true;
+                watcher.EnableRaisingEvents = true;
+                while (!stoppingToken.IsCancellationRequested)
+                {
+                    watcher.WaitForChanged(WatcherChangeTypes.Created, Timeout.Infinite);
+                }
+            });
+        }
+
+        private static async void ParseFile(string path)
+        {
+            var done = false;
+            while (!done)
+            {
+                try
+                {
+                    Indexer.AddToIndex(path);
+                    Ewh.WaitOne();
+                    var newContent = Indexer.GetFromIndex(path);
+                    if (newContent is not null) Patcher.PatchContent(newContent);
+                    done = true;
+                }
+                catch (EndOfStreamException)
+                {
+                    await Task.Delay(500);
                 }
             }
-
-            Thread.Sleep(300);
         }
     }
 
-    private static StreamReader GetLogStream(string logFile)
+    internal class LogFileWatcher(ILogger<LogFileWatcher> logger) : BackgroundService
     {
-        var fs = new FileStream(logFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-        var sr = new StreamReader(fs);
-        sr.BaseStream.Seek(0, SeekOrigin.End);
-        return sr;
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            await Task.Run(() =>
+            {
+                using var watcher = new FileSystemWatcher(Indexer.WorkingDirectory);
+                watcher.NotifyFilter = NotifyFilters.FileName;
+                watcher.Filter = "*.txt";
+                watcher.IncludeSubdirectories = false;
+                watcher.Created += (_, e) =>
+                {
+                    _logwatcherStoppingToken.Cancel();
+                    _logwatcherStoppingToken = new CancellationTokenSource();
+
+                    // Assuming a new log file means a client restart, it's likely not loading any file.
+                    // Let's take initiative and free any tasks.
+                    Ewh.Set();
+
+                    logger.LogTrace("Rotated log parsing to {file}", e.Name);
+                };
+                watcher.EnableRaisingEvents = true;
+
+                while (true)
+                {
+                    watcher.WaitForChanged(WatcherChangeTypes.Created, Timeout.Infinite);
+                }
+            });
+        }
     }
 
-    private static string GetNewestLog()
+    internal class Logwatcher(ILogger<Logwatcher> logger) : BackgroundService
     {
-        return new DirectoryInfo(Indexer.WorkingDirectory).GetFiles("*.txt")
-            .OrderByDescending(file => file.CreationTimeUtc).First().FullName;
+        private static StreamReader GetLogStream(string logFile)
+        {
+            var fs = new FileStream(logFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            var sr = new StreamReader(fs);
+            sr.BaseStream.Seek(0, SeekOrigin.End);
+            return sr;
+        }
+
+        private static string GetNewestLog()
+        {
+            return new DirectoryInfo(Indexer.WorkingDirectory).GetFiles("*.txt")
+                .OrderByDescending(file => file.CreationTimeUtc).First().FullName;
+        }
+
+
+        protected override async Task ExecuteAsync(CancellationToken applicationQuitToken)
+        {
+            var logPath = GetNewestLog();
+            var sr = GetLogStream(logPath);
+            logger.LogTrace("Now reading logfile {path}", logPath);
+            while (!_logwatcherStoppingToken.IsCancellationRequested || !applicationQuitToken.IsCancellationRequested)
+            {
+                var output = await sr.ReadToEndAsync(applicationQuitToken);
+                var lines = output.Split(Environment.NewLine);
+                foreach (var line in lines)
+                {
+                    switch (line)
+                    {
+                        case not null when line.Contains(LoadStartIndicator):
+                            logger.LogTrace("Expecting world load: {msg}", line);
+                            Ewh.Reset();
+                            break;
+                        case not null when line.Contains(LoadStopIndicator):
+                            logger.LogTrace("Expecting world load finish: {msg}", line);
+                            Ewh.Set();
+                            break;
+                    }
+                }
+
+                await Task.Delay(300, applicationQuitToken);
+            }
+        }
     }
 }

--- a/AdGoBye/Live.cs
+++ b/AdGoBye/Live.cs
@@ -20,7 +20,7 @@ public static class Live
         services.AddHostedService<ContentWatcher>();
     }
 
-    internal class ContentWatcher(ILogger<ContentWatcher> logger, Indexer indexer) : BackgroundService
+    internal class ContentWatcher(ILogger<ContentWatcher> logger, Indexer indexer, Patcher patcher) : BackgroundService
     {
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
@@ -87,7 +87,7 @@ public static class Live
                     indexer.AddToIndex(path);
                     Ewh.WaitOne();
                     var newContent = Indexer.GetFromIndex(path);
-                    if (newContent is not null) Patcher.PatchContent(newContent);
+                    if (newContent is not null) patcher.PatchContent(newContent);
                     done = true;
                 }
                 catch (EndOfStreamException)

--- a/AdGoBye/Patcher.cs
+++ b/AdGoBye/Patcher.cs
@@ -75,7 +75,7 @@ namespace AdGoBye
                 }
             }
 
-            if (blocklists.Blocks is not null && !pluginOverridesBlocklist &&
+            if (blocklists.Blocks.Count != 0 && !pluginOverridesBlocklist &&
                 !content.VersionMeta.PatchedBy.Contains("Blocklist"))
             {
                 foreach (var block in blocklists.Blocks.Where(block => block.Key.Equals(content.Id)))

--- a/AdGoBye/Patcher.cs
+++ b/AdGoBye/Patcher.cs
@@ -5,11 +5,11 @@ using Serilog;
 
 namespace AdGoBye
 {
-    internal class Patcher
+    internal class Patcher(Blocklist blocklists)
     {
         private static readonly ILogger Logger = Log.ForContext(typeof(Patcher));
 
-        internal static void PatchContent(Content content)
+        internal void PatchContent(Content content)
         {
             if (content.Type is not ContentType.World) return;
             Logger.Information("Processing {ID} ({directory})", content.Id, content.VersionMeta.Path);
@@ -73,14 +73,14 @@ namespace AdGoBye
                 }
             }
 
-            if (Blocklist.Blocks is not null && !pluginOverridesBlocklist &&
+            if (blocklists.Blocks is not null && !pluginOverridesBlocklist &&
                 !content.VersionMeta.PatchedBy.Contains("Blocklist"))
             {
-                foreach (var block in Blocklist.Blocks.Where(block => block.Key.Equals(content.Id)))
+                foreach (var block in blocklists.Blocks.Where(block => block.Key.Equals(content.Id)))
                 {
                     try
                     {
-                        if (Blocklist.Patch(content, container, [.. block.Value]))
+                        if (blocklists.Patch(content, container, [.. block.Value]))
                             someoneModifiedBundle = true;
                     }
                     catch (Exception e)

--- a/AdGoBye/Program.cs
+++ b/AdGoBye/Program.cs
@@ -95,6 +95,8 @@ internal class Program
         var patcher = host.Services.GetRequiredService<Patcher>();
         var globalOptions = host.Services.GetRequiredService<IOptions<Settings.SettingsOptionsV2>>().Value;
 
+        await host.StartAsync();
+
         if (globalOptions.EnableUpdateCheck) Updater.CheckUpdates();
 
         await using var db = new AdGoByeContext();
@@ -110,7 +112,7 @@ internal class Program
             }, content => { patcher.PatchContent(content); });
 
         await db.SaveChangesAsync();
-
-        if (globalOptions.EnableLive) host.Run();
+        if (!globalOptions.EnableLive) await host.StopAsync();
+        await host.WaitForShutdownAsync();
     }
 }

--- a/AdGoBye/Program.cs
+++ b/AdGoBye/Program.cs
@@ -68,7 +68,6 @@ internal class Program
         _isLogSet = true;
 
         builder.Configuration.AddJsonFile("appsettings.json").Build();
-        // TODO: I'm not sure if this is valid like this, I doubt it 
         Settings.ConvertV1SettingsToV2(builder.Configuration);
         ((IConfigurationRoot)builder.Configuration).Reload();
 

--- a/AdGoBye/Program.cs
+++ b/AdGoBye/Program.cs
@@ -42,7 +42,10 @@ internal class Program
 
         Console.OutputEncoding = Encoding.UTF8;
 
-        var levelSwitch = new LoggingLevelSwitch { MinimumLevel = (LogEventLevel)Settings.Options.LogLevel };
+        var levelSwitch = new LoggingLevelSwitch
+        {
+            MinimumLevel = (LogEventLevel)Settings.Options.LogLevel
+        };
 
         var builder = Host.CreateApplicationBuilder();
         builder.Services.AddSerilog((_, configuration) =>
@@ -53,6 +56,7 @@ internal class Program
                 )
         );
         builder.Services.RegisterLiveServices();
+        builder.Services.AddSingleton<Indexer>();
         _isLogSet = true;
         var host = builder.Build();
 
@@ -68,7 +72,6 @@ internal class Program
         await db.Database.MigrateAsync();
         Blocklist.UpdateNetworkBlocklists();
         Blocklist.ParseAllBlocklists();
-        Indexer.ManageIndex();
 
         PluginLoader.LoadPlugins();
         foreach (var plugin in PluginLoader.LoadedPlugins)
@@ -87,7 +90,10 @@ internal class Program
             Blocklist.Blocks?.Count, db.Content.Count());
 
         Parallel.ForEach(db.Content.Include(content => content.VersionMeta),
-            new ParallelOptions { MaxDegreeOfParallelism = Settings.Options.MaxPatchThreads }, content =>
+            new ParallelOptions
+            {
+                MaxDegreeOfParallelism = Settings.Options.MaxPatchThreads
+            }, content =>
             {
                 if (content.Type != ContentType.World) return;
                 Patcher.PatchContent(content);

--- a/AdGoBye/Program.cs
+++ b/AdGoBye/Program.cs
@@ -109,11 +109,7 @@ internal class Program
             new ParallelOptions
             {
                 MaxDegreeOfParallelism = globalOptions.MaxPatchThreads
-            }, content =>
-            {
-                if (content.Type != ContentType.World) return;
-                patcher.PatchContent(content);
-            });
+            }, content => { patcher.PatchContent(content); });
 
         await db.SaveChangesAsync();
 

--- a/AdGoBye/Program.cs
+++ b/AdGoBye/Program.cs
@@ -68,17 +68,9 @@ internal class Program
         _isLogSet = true;
 
         builder.Configuration.AddJsonFile("appsettings.json").Build();
+        // TODO: I'm not sure if this is valid like this, I doubt it 
         Settings.ConvertV1SettingsToV2(builder.Configuration);
         ((IConfigurationRoot)builder.Configuration).Reload();
-
-        builder.Services.AddSerilog((_, configuration) =>
-            configuration.Enrich.FromLogContext().MinimumLevel.ControlledBy(levelSwitch)
-                .WriteTo.Console(new ExpressionTemplate(
-                    "[{@t:HH:mm:ss} {@l:u3} {Coalesce(Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1),'<none>')}] {@m}\n{@x}",
-                    theme: TemplateTheme.Literate)
-                )
-        );
-        _isLogSet = true;
 
 
         builder.Services.RegisterLiveServices();

--- a/AdGoBye/Program.cs
+++ b/AdGoBye/Program.cs
@@ -102,11 +102,8 @@ internal class Program
         await using var db = new AdGoByeContext();
         await db.Database.MigrateAsync();
 
-        if (blocklists.Blocks == null || blocklists.Blocks.Count == 0)
-            logger.LogInformation("No blocklist has been loaded, is this intentional?");
-
         logger.LogInformation("Loaded blocks for {blockCount} worlds and indexed {indexCount} pieces of content",
-            blocklists.Blocks?.Count, db.Content.Count());
+            blocklists.Blocks.Count, db.Content.Count());
 
         Parallel.ForEach(db.Content.Include(content => content.VersionMeta),
             new ParallelOptions

--- a/AdGoBye/Program.cs
+++ b/AdGoBye/Program.cs
@@ -88,14 +88,12 @@ internal class Program
         builder.Services.AddSingleton<Patcher>();
         builder.Services.AddSingleton<PluginLoader>();
         var host = builder.Build();
-
-
+        SingleInstance.Attach();
 
         var logger = host.Services.GetRequiredService<ILogger<Program>>();
         var blocklists = host.Services.GetRequiredService<Blocklist>();
         var patcher = host.Services.GetRequiredService<Patcher>();
         var globalOptions = host.Services.GetRequiredService<IOptions<Settings.SettingsOptionsV2>>().Value;
-        SingleInstance.Attach();
 
         if (globalOptions.EnableUpdateCheck) Updater.CheckUpdates();
 

--- a/AdGoBye/Program.cs
+++ b/AdGoBye/Program.cs
@@ -2,7 +2,6 @@ global using AdGoBye.Types;
 using System.Text;
 using AdGoBye;
 using AdGoBye.Database;
-using AdGoBye.Plugins;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -87,6 +86,7 @@ internal class Program
         builder.Services.AddSingleton<Indexer>();
         builder.Services.AddSingleton<Blocklist>();
         builder.Services.AddSingleton<Patcher>();
+        builder.Services.AddSingleton<PluginLoader>();
         var host = builder.Build();
 
 
@@ -101,17 +101,6 @@ internal class Program
 
         await using var db = new AdGoByeContext();
         await db.Database.MigrateAsync();
-
-        PluginLoader.LoadPlugins();
-        foreach (var plugin in PluginLoader.LoadedPlugins)
-        {
-            logger.LogInformation("Plugin {Name} ({Maintainer}) v{Version} is loaded.", plugin.Name, plugin.Maintainer,
-                plugin.Version);
-            logger.LogInformation("Plugin type: {Type}", plugin.Instance.PluginType());
-
-            if (plugin.Instance.PluginType() == EPluginType.ContentSpecific && plugin.Instance.ResponsibleForContentIds() is not null)
-                logger.LogInformation("Responsible for {IDs}", plugin.Instance.ResponsibleForContentIds());
-        }
 
         if (blocklists.Blocks == null || blocklists.Blocks.Count == 0)
             logger.LogInformation("No blocklist has been loaded, is this intentional?");

--- a/AdGoBye/Settings.cs
+++ b/AdGoBye/Settings.cs
@@ -1,12 +1,152 @@
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.Configuration;
 
 namespace AdGoBye;
 
 public class Settings
 {
+    public class SettingsOptionsV3
+    {
+        public int ConfigVersion { get; set; } = 3;
+        public BlocklistOptions Blocklist { get; set; } = new();
+        public IndexerOptions Indexer { get; set; } = new();
+        public PatcherOptions Patcher { get; set; } = new();
+        public bool EnableUpdateCheck { get; set; }
+        public bool EnableLive { get; set; }
+        public bool DisablePluginInstallWarning { get; set; }
+    }
+
+    public class SettingsOptionsV2
+    {
+        public int ConfigVersion { get; set; } = 2;
+        public BlocklistOptions Blocklist { get; set; } = new();
+        public IndexerOptions Indexer { get; set; } = new();
+        public PatcherOptions Patcher { get; set; } = new();
+        public bool EnableUpdateCheck { get; set; }
+        public int LogLevel { get; set; }
+        public bool EnableLive { get; set; }
+        public bool DisablePluginInstallWarning { get; set; }
+        public int MaxIndexerThreads { get; set; }
+        public int MaxPatchThreads { get; set; }
+    }
+
+    public class BlocklistOptions
+    {
+        public string[] BlocklistUrls { get; set; } = [];
+        public bool SendUnmatchedObjectsToDevs { get; set; }
+        public string? BlocklistUnmatchedServer { get; set; }
+    }
+
+    public class IndexerOptions
+    {
+        public string? WorkingFolder { get; set; }
+        public string[]? Allowlist { get; set; }
+
+        public int MaxIndexerThreads { get; set; }
+    }
+
+    public class PatcherOptions
+    {
+        public bool DryRun { get; set; }
+        public bool DisableBackupFile { get; set; }
+        public bool EnableRecompression { get; set; }
+        public int RecompressionMemoryMaxMB { get; set; }
+        public int ZipBombSizeLimitMB { get; set; }
+        public int MaxPatchThreads { get; set; }
+    }
+
+    #region Old Settings Versions
+
+    public class SettingsOptionsV1
+    {
+        public string[]? Allowlist { get; set; }
+        public string? WorkingFolder { get; set; }
+        public int LogLevel { get; set; }
+        public bool EnableLive { get; set; }
+        public bool DryRun { get; set; }
+        public string[] BlocklistUrLs { get; set; } = [];
+
+        // Null because v2.1.0 doesn't have these yet
+        public string? BlocklistUnmatchedServer { get; set; }
+        public bool? SendUnmatchedObjectsToDevs { get; set; }
+        public bool? EnableUpdateCheck { get; set; }
+        public bool? DisablePluginInstallWarning { get; set; }
+        public bool? DisableBackupFile { get; set; }
+        public bool? EnableRecompression { get; set; }
+        public int? MaxIndexerThreads { get; set; }
+        public int? MaxPatchThreads { get; set; }
+        public int? RecompressionMemoryMaxMB { get; set; }
+        public int? ZipBombSizeLimitMB { get; set; }
+    }
+
+    #endregion Old Settings Versions
+
     #region appsettings.json conversion methods
+
+    internal static void ConvertV2SettingsToV3(IConfigurationRoot? config)
+    {
+        var section = config?.GetRequiredSection("Settings");
+
+        var configVersion = section?.GetValue<int?>("ConfigVersion");
+        if (configVersion is not 2) return;
+
+        var configJsonObject = (JsonObject?)JsonNode.Parse(File.ReadAllText("appsettings.json"));
+        if (configJsonObject is null) return;
+
+        var modifiedSettingsSection = configJsonObject["Settings"]!.AsObject();
+        modifiedSettingsSection.Remove("LogLevel");
+        modifiedSettingsSection.Remove("MaxIndexerThreads");
+        modifiedSettingsSection.Remove("MaxPatchThreads");
+        modifiedSettingsSection["Patcher"]!["MaxPatchThreads"] = section?.GetValue<int?>("MaxPatchThreads") ?? 16;
+        modifiedSettingsSection["Indexer"]!["MaxIndexerThreads"] = section?.GetValue<int?>("MaxIndexerThreads") ?? 16;
+        modifiedSettingsSection["ConfigVersion"] = 3;
+        configJsonObject["Settings"]!.ReplaceWith(modifiedSettingsSection);
+
+        configJsonObject.Remove("Logging");
+        configJsonObject["Serilog"] = new JsonObject
+        {
+            ["Using"] = new JsonArray
+            {
+                "Serilog.Sinks.Console"
+            },
+            ["MinimumLevel"] = new JsonObject
+            {
+                ["Default"] = "Verbose",
+                ["Override"] = new JsonObject
+                {
+                    ["Microsoft"] = "Warning"
+                }
+            },
+            ["WriteTo"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["Name"] = "Console",
+                    ["Args"] = new JsonObject
+                    {
+                        ["formatter"] = new JsonObject
+                        {
+                            ["type"] = "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
+                            ["template"] = "[{@t:HH:mm:ss} {@l:u3} {Coalesce(Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1),'<none>')}] {@m}\n{@x}",
+                            ["theme"] = "Serilog.Templates.Themes.TemplateTheme::Literate, Serilog.Expressions"
+                        }
+
+                    }
+                }
+            }
+        };
+
+        File.WriteAllText("appsettings.json",
+            configJsonObject.ToJsonString(new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+            }));
+    }
 
     internal static bool ConvertV1SettingsToV2(IConfigurationRoot? config)
     {
@@ -42,7 +182,7 @@ public class Settings
             settingsV2.MaxIndexerThreads = settingsV1.MaxIndexerThreads ?? 16;
             settingsV2.MaxPatchThreads = settingsV1.MaxPatchThreads ?? 16;
 
-            var jsonObject = JsonObject.Parse(File.ReadAllText("appsettings.json")) ?? new JsonObject();
+            var jsonObject = JsonNode.Parse(File.ReadAllText("appsettings.json")) ?? new JsonObject();
             jsonObject["Settings"] = JsonNode.Parse(JsonSerializer.Serialize(settingsV2));
             File.WriteAllText("appsettings.json",
                 jsonObject.ToJsonString(new JsonSerializerOptions
@@ -57,66 +197,4 @@ public class Settings
     }
 
     #endregion appsettings.json conversion methods
-
-    public class SettingsOptionsV2
-    {
-        public int ConfigVersion { get; set; } = 2;
-        public BlocklistOptions Blocklist { get; set; } = new();
-        public IndexerOptions Indexer { get; set; } = new();
-        public PatcherOptions Patcher { get; set; } = new();
-        public bool EnableUpdateCheck { get; set; }
-        public int LogLevel { get; set; }
-        public bool EnableLive { get; set; }
-        public bool DisablePluginInstallWarning { get; set; }
-        public int MaxIndexerThreads { get; set; }
-        public int MaxPatchThreads { get; set; }
-    }
-
-    public class BlocklistOptions
-    {
-        public string[] BlocklistUrls { get; set; } = [];
-        public bool SendUnmatchedObjectsToDevs { get; set; }
-        public string? BlocklistUnmatchedServer { get; set; }
-    }
-
-    public class IndexerOptions
-    {
-        public string? WorkingFolder { get; set; }
-        public string[]? Allowlist { get; set; }
-    }
-
-    public class PatcherOptions
-    {
-        public bool DryRun { get; set; }
-        public bool DisableBackupFile { get; set; }
-        public bool EnableRecompression { get; set; }
-        public int RecompressionMemoryMaxMB { get; set; }
-        public int ZipBombSizeLimitMB { get; set; }
-    }
-
-    #region Old Settings Versions
-
-    public class SettingsOptionsV1
-    {
-        public string[]? Allowlist { get; set; }
-        public string? WorkingFolder { get; set; }
-        public int LogLevel { get; set; }
-        public bool EnableLive { get; set; }
-        public bool DryRun { get; set; }
-        public string[] BlocklistUrLs { get; set; } = [];
-
-        // Null because v2.1.0 doesn't have these yet
-        public string? BlocklistUnmatchedServer { get; set; }
-        public bool? SendUnmatchedObjectsToDevs { get; set; }
-        public bool? EnableUpdateCheck { get; set; }
-        public bool? DisablePluginInstallWarning { get; set; }
-        public bool? DisableBackupFile { get; set; }
-        public bool? EnableRecompression { get; set; }
-        public int? MaxIndexerThreads { get; set; }
-        public int? MaxPatchThreads { get; set; }
-        public int? RecompressionMemoryMaxMB { get; set; }
-        public int? ZipBombSizeLimitMB { get; set; }
-    }
-
-    #endregion Old Settings Versions
 }

--- a/AdGoBye/Settings.cs
+++ b/AdGoBye/Settings.cs
@@ -4,25 +4,11 @@ using Microsoft.Extensions.Configuration;
 
 namespace AdGoBye;
 
-public static class Settings
+public class Settings
 {
-    static Settings()
-    {
-        var config = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.json")
-            .Build();
-
-        if (ConvertV1SettingsToV2(config))
-            config.Reload();
-
-        Options = config.GetRequiredSection("Settings").Get<SettingsOptionsV2>() ?? new SettingsOptionsV2();
-    }
-
-    public static SettingsOptionsV2 Options { get; set; }
-
     #region appsettings.json conversion methods
 
-    private static bool ConvertV1SettingsToV2(IConfigurationRoot? config)
+    internal static bool ConvertV1SettingsToV2(IConfigurationRoot? config)
     {
         var section = config?.GetRequiredSection("Settings");
         if (section == null)
@@ -59,7 +45,10 @@ public static class Settings
             var jsonObject = JsonObject.Parse(File.ReadAllText("appsettings.json")) ?? new JsonObject();
             jsonObject["Settings"] = JsonNode.Parse(JsonSerializer.Serialize(settingsV2));
             File.WriteAllText("appsettings.json",
-                jsonObject.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+                jsonObject.ToJsonString(new JsonSerializerOptions
+                {
+                    WriteIndented = true
+                }));
 
             return true;
         }

--- a/AdGoBye/appsettings.json
+++ b/AdGoBye/appsettings.json
@@ -1,6 +1,6 @@
 {
   "Settings": {
-    "ConfigVersion": 2,
+    "ConfigVersion": 3,
     "Blocklist": {
       "BlocklistUrls": [],
       "SendUnmatchedObjectsToDevs": false,
@@ -8,27 +8,42 @@
     },
     "Indexer": {
       "WorkingFolder": null,
-      "Allowlist": []
+      "Allowlist": [],
+      "MaxIndexerThreads": 16
     },
     "Patcher": {
       "DryRun": false,
       "DisableBackupFile": false,
       "EnableRecompression": false,
       "RecompressionMemoryMaxMB": 250,
-      "ZipBombSizeLimitMB": 8000
+      "ZipBombSizeLimitMB": 8000,
+      "MaxPatchThreads": 16
     },
     "EnableUpdateCheck": true,
-    "LogLevel": 0,
     "EnableLive": true,
-    "DisablePluginInstallWarning": false,
-    "MaxIndexerThreads": 16,
-    "MaxPatchThreads": 16
+    "DisablePluginInstallWarning": false
   },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
-    }
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console"
+    ],
+    "MinimumLevel": {
+      "Default": "Verbose",
+      "Override": {
+        "Microsoft": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": {
+            "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
+            "template": "[{@t:HH:mm:ss} {@l:u3} {Coalesce(Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1),'<none>')}] {@m}\n{@x}",
+            "theme": "Serilog.Templates.Themes.TemplateTheme::Literate, Serilog.Expressions"
+          }
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
This is part refactor PR and part a RFC.

[Generic Host](https://learn.microsoft.com/en-us/dotnet/core/extensions/generic-host?tabs=appbuilder) is .NET's infrastructure for things that apps might need, like configuration or logging. A notable change is that we're pawning off our classes to it as services, so that they can be dependency injected and / or 'hosted'.

Because access to the Logger from dependency injection is not static, I've done the drudgework to remove the static modifier from relevant classes, which undoes that cardinal sin and I believe opens up mocking the dependency classes for testing since we're not directly calling the static classes.

I also managed to move some of the initialization code into the classes themselves rather than calling them in main.

On the hosted part, Generic Host gives us the infrastructure to gracefully shut down 'hosted' services (that is, long running async tasks), which doesn't actually matter on our end because Live is the only thing using that and all the operations it can call should be atomic.

## RFC
Despite doing this with hindsight of #34, I'm not sure how much I like this code.
There are a few hacks in there to make it work with like before, those are probably fixable with enough knowledge, but this process can feel rather circle-in-square-hole at times.

Speaking in a functional opinion, this entire process is also very Enterprise-y. 
Generic Host is the genericization of ASP.NET, where paradigms like hosted services make sense since you might not want to drop a request when you shutdown your web server. The documentation and syntax on working with it can feel rather alien at times.

Assuming we don't use GH but take the changes from here, we'd just be initializing global classes and passing them around that way rather than passing them to GH. And at that point, we'd be re-engineering the ~~god object~~ infrastructure that GH provides to us.
